### PR TITLE
Remove the no recreate option to let the vhosts be updated if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ start: ## Start the environment
 		echo 'The default configuration has been applied because the "docker-env" file was not configured.'; \
 		cp docker-env.dist docker-env; \
 	fi
-	$(DOCKER_COMPOSE) up -d --remove-orphans --no-recreate
+	$(DOCKER_COMPOSE) up -d --remove-orphans
 
 stop: ## Stop the environment
 	$(DOCKER_COMPOSE) stop


### PR DESCRIPTION
The option "--no-recreate" doesn't allow to let the vhosts be updated if needed