### PR TITLE
Turn off "opcache.fast_shutdown" setting

### DIFF
--- a/php/conf/php-cli.ini
+++ b/php/conf/php-cli.ini
@@ -34,7 +34,6 @@ session.use_strict_mode=1
 opcache.enable_cli=On
 opcache.enable_file_override=On
 opcache.error_log=/var/log/apache2/opcache.log
-opcache.fast_shutdown=On
 opcache.force_restart_timeout=600
 opcache.interned_strings_buffer=32
 opcache.load_comments=On

--- a/php/conf/php.ini
+++ b/php/conf/php.ini
@@ -34,7 +34,6 @@ session.use_strict_mode=1
 opcache.enable_cli=On
 opcache.enable_file_override=On
 opcache.error_log=/var/log/apache2/opcache.log
-opcache.fast_shutdown=On
 opcache.force_restart_timeout=600
 opcache.interned_strings_buffer=32
 opcache.load_comments=On


### PR DESCRIPTION
Because of weird behaviors like those discussed in https://github.com/zendtech/ZendOptimizerPlus/issues/146.